### PR TITLE
优化 recv 方法性能

### DIFF
--- a/ssdb/ssdb.go
+++ b/ssdb/ssdb.go
@@ -1,15 +1,22 @@
 package ssdb
 
 import (
+	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
+	"io"
 	"net"
 	"strconv"
 )
 
+var (
+	ErrProtocolError = errors.New("ssdb protocol error")
+)
+
 type Client struct {
-	sock     *net.TCPConn
-	recv_buf bytes.Buffer
+	sock   *net.TCPConn
+	reader *bufio.Reader
 }
 
 func Connect(ip string, port int) (*Client, error) {
@@ -23,6 +30,7 @@ func Connect(ip string, port int) (*Client, error) {
 	}
 	var c Client
 	c.sock = sock
+	c.reader = bufio.NewReader(sock)
 	return &c, nil
 }
 
@@ -75,7 +83,7 @@ func (c *Client) Del(key string) (interface{}, error) {
 }
 
 func (c *Client) Send(args ...interface{}) error {
-	return c.send(args);
+	return c.send(args)
 }
 
 func (c *Client) send(args []interface{}) error {
@@ -122,63 +130,40 @@ func (c *Client) send(args []interface{}) error {
 }
 
 func (c *Client) Recv() ([]string, error) {
-	return c.recv();
+	return c.recv()
 }
 
 func (c *Client) recv() ([]string, error) {
-	var tmp [1]byte
-	for {
-		resp := c.parse()
-		if resp == nil || len(resp) > 0 {
-			return resp, nil
-		}
-		n, err := c.sock.Read(tmp[0:])
-		if err != nil {
-			return nil, err
-		}
-		c.recv_buf.Write(tmp[0:n])
-	}
-}
-
-func (c *Client) parse() []string {
 	resp := []string{}
-	buf := c.recv_buf.Bytes()
-	var idx, offset int
-	idx = 0
-	offset = 0
-
+	bb := bytes.NewBuffer(nil)
 	for {
-		idx = bytes.IndexByte(buf[offset:], '\n')
-		if idx == -1 {
+		l, _, e := c.reader.ReadLine()
+		if e != nil {
+			return nil, e
+		}
+		if len(l) == 0 {
+			//empty line found
 			break
 		}
-		p := buf[offset : offset+idx]
-		offset += idx + 1
-		//fmt.Printf("> [%s]\n", p);
-		if len(p) == 0 || (len(p) == 1 && p[0] == '\r') {
-			if len(resp) == 0 {
-				continue
-			} else {
-				c.recv_buf.Next(offset)
-				return resp
-			}
+		size, e := strconv.Atoi(string(l))
+		if e != nil {
+			return nil, e
 		}
-
-		size, err := strconv.Atoi(string(p))
-		if err != nil || size < 0 {
-			return nil
+		if size < 0 {
+			return nil, ErrProtocolError
 		}
-		if offset+size >= c.recv_buf.Len() {
-			break
+		bb.Reset()
+		_, e = io.CopyN(bb, c.reader, int64(size+1))
+		if e != nil {
+			return nil, e
 		}
-
-		v := buf[offset : offset+size]
-		resp = append(resp, string(v))
-		offset += size + 1
+		buf := bb.Bytes()
+		if buf[size] != '\n' {
+			return nil, ErrProtocolError
+		}
+		resp = append(resp, string(buf[:size]))
 	}
-
-	//fmt.Printf("buf.size: %d packet not ready...\n", len(buf))
-	return []string{}
+	return resp, nil
 }
 
 // Close The Client Connection

--- a/ssdb/ssdb.go
+++ b/ssdb/ssdb.go
@@ -95,11 +95,10 @@ func (c *Client) send(args []interface{}) error {
 				buf.WriteByte('\n')
 			}
 			continue
-		case int:
+		case int, int8, int16, int32, int64,
+			uint, uint8, uint16, uint32, uint64:
 			s = fmt.Sprintf("%d", arg)
-		case int64:
-			s = fmt.Sprintf("%d", arg)
-		case float64:
+		case float32, float64, complex64, complex128:
 			s = fmt.Sprintf("%f", arg)
 		case bool:
 			if arg {

--- a/ssdb/ssdb_test.go
+++ b/ssdb/ssdb_test.go
@@ -1,0 +1,60 @@
+package ssdb
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func makeValue(size int) []byte {
+	val := make([]byte, size)
+	for i := 0; i < size; i++ {
+		str := "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+		val[i] = str[rand.Int31n(int32(62))]
+	}
+	return val
+}
+
+func benchmarkSSDBGoRecv(valSize, batchSize int, b *testing.B) {
+	c, e := Connect("127.0.0.1", 8888)
+	if e != nil {
+		b.Fatal(e)
+	}
+	defer c.Close()
+	testKey1 := "ssdb.benchmark.key1"
+	defer c.Do("hclear", testKey1)
+	for n := 0; n < batchSize; n++ {
+		c.Do("hset", testKey1, n, makeValue(valSize))
+	}
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		_, e := c.Do("hscan", testKey1, "", "", batchSize)
+		if e != nil {
+			b.Error(e)
+		}
+	}
+}
+
+// go test -bench=.
+// go test -bench=BenchmarkSSDBGoRecv_1k_10 -benchtime=20s
+// go test -run=none -bench=BenchmarkSSDBGoRecv_10k_50 -cpuprofile=cprof
+func BenchmarkSSDBGoRecv_64b_10(b *testing.B) {
+	benchmarkSSDBGoRecv(64, 10, b)
+}
+func BenchmarkSSDBGoRecv_64b_50(b *testing.B) {
+	benchmarkSSDBGoRecv(64, 50, b)
+}
+
+func BenchmarkSSDBGoRecv_1k_10(b *testing.B) {
+	benchmarkSSDBGoRecv(1*1024, 10, b)
+}
+func BenchmarkSSDBGoRecv_1k_50(b *testing.B) {
+	benchmarkSSDBGoRecv(1*1024, 50, b)
+}
+
+func BenchmarkSSDBGoRecv_10k_10(b *testing.B) {
+	benchmarkSSDBGoRecv(10*1024, 10, b)
+}
+
+func BenchmarkSSDBGoRecv_10k_50(b *testing.B) {
+	benchmarkSSDBGoRecv(10*1024, 50, b)
+}


### PR DESCRIPTION
golang 中的 io 函数会触发 runtime 的协程调度器,在 Client.recv 中按字节读取返回数据,会导致频繁调度操作,严重拖慢性能