### PR TITLE
fix test.go path error. fixes #5 #8

### DIFF
--- a/test.go
+++ b/test.go
@@ -4,7 +4,8 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"./ssdb"
+
+	"github.com/ssdb/gossdb/ssdb"
 )
 
 func main() {


### PR DESCRIPTION
Use local `./ssdb` path will make `go get` failed:

```
go get -v -u github.com/ssdb/gossdb
github.com/ssdb/gossdb (download)
package _/Users/fannheyward/src/github.com/ssdb/gossdb/ssdb: cannot find package "_/Users/fannheyward/src/github.com/ssdb/gossdb/ssdb" in any of:
	/usr/local/Cellar/go/1.8.3/libexec/src/_/Users/fannheyward/src/github.com/ssdb/gossdb/ssdb (from $GOROOT)
	/Users/fannheyward/src/_/Users/fannheyward/src/github.com/ssdb/gossdb/ssdb (from $GOPATH)
```